### PR TITLE
host-guest: create a proxy for the pulse socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "krun"
 version = "0.1.0"
 dependencies = [
@@ -233,6 +245,23 @@ dependencies = [
  "rustix",
  "tempfile",
  "utils",
+]
+
+[[package]]
+name = "krun-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bpaf",
+ "env_logger",
+ "log",
+ "nix",
+ "rustix",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "utils",
+ "vsock",
 ]
 
 [[package]]
@@ -279,6 +308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +332,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -373,6 +412,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +492,16 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 [[package]]
 name = "utils"
 version = "0.0.0"
+
+[[package]]
+name = "vsock"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82e291049535877d607cd861b6820eb622538c88853c1c01df72b1dbed4e32d"
+dependencies = [
+ "libc",
+ "nix",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/krun-guest/src/lib.rs
+++ b/crates/krun-guest/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cli_options;
 pub mod fex;
 pub mod mount;
 pub mod net;
+pub mod pulse;
 pub mod sommelier;
 pub mod user;

--- a/crates/krun-guest/src/pulse.rs
+++ b/crates/krun-guest/src/pulse.rs
@@ -1,0 +1,24 @@
+use std::{fs, path::PathBuf, process::Command};
+
+use anyhow::{Context, Result};
+use utils::env::find_in_path;
+
+pub fn setup_pulse_proxy(run_path: PathBuf) -> Result<()> {
+    if let Some(socat_path) = find_in_path("socat")? {
+        let pulse_path = run_path.join("pulse");
+        fs::create_dir(&pulse_path)
+            .context("Failed to create `pulse` directory in `XDG_RUNTIME_DIR`")?;
+        let pulse_path = pulse_path.join("native");
+        Command::new(socat_path)
+            .arg(format!(
+                "UNIX-LISTEN:{},fork",
+                pulse_path
+                    .to_str()
+                    .expect("pulse_path should not contain invalid UTF-8")
+            ))
+            .arg("VSOCK-CONNECT:2:3333")
+            .spawn()
+            .context("Failed to execute `socat` as child process")?;
+    }
+    Ok(())
+}

--- a/crates/krun-guest/src/user.rs
+++ b/crates/krun-guest/src/user.rs
@@ -2,6 +2,7 @@ use std::{
     env,
     fs::{read_dir, Permissions},
     os::unix::fs::{chown, PermissionsExt as _},
+    path::Path,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -51,6 +52,11 @@ fn setup_directories(uid: Uid, gid: Gid) -> Result<()> {
             chown(&path, Some(uid.into()), Some(gid.into()))
                 .with_context(|| format!("Failed to chown {path:?}"))?;
         }
+    }
+
+    if Path::new("/dev/vsock").exists() {
+        chown("/dev/vsock", Some(uid.into()), Some(gid.into()))
+            .with_context(|| "Failed to chown /dev/vsock".to_string())?;
     }
 
     Ok(())

--- a/crates/krun/src/bin/krun.rs
+++ b/crates/krun/src/bin/krun.rs
@@ -4,6 +4,7 @@ use std::{
     fs,
     io::ErrorKind,
     os::fd::{IntoRawFd, OwnedFd},
+    path::Path,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -12,9 +13,10 @@ use krun::{
     net::{connect_to_passt, start_passt, NetMode},
 };
 use krun_sys::{
-    krun_create_ctx, krun_set_exec, krun_set_gpu_options, krun_set_log_level, krun_set_passt_fd,
-    krun_set_root, krun_set_vm_config, krun_set_workdir, krun_start_enter, VIRGLRENDERER_DRM,
-    VIRGLRENDERER_THREAD_SYNC, VIRGLRENDERER_USE_ASYNC_FENCE_CB, VIRGLRENDERER_USE_EGL,
+    krun_add_vsock_port, krun_create_ctx, krun_set_exec, krun_set_gpu_options, krun_set_log_level,
+    krun_set_passt_fd, krun_set_root, krun_set_vm_config, krun_set_workdir, krun_start_enter,
+    VIRGLRENDERER_DRM, VIRGLRENDERER_THREAD_SYNC, VIRGLRENDERER_USE_ASYNC_FENCE_CB,
+    VIRGLRENDERER_USE_EGL,
 };
 use log::debug;
 use nix::unistd::User;
@@ -112,6 +114,24 @@ fn main() -> Result<()> {
         if err < 0 {
             let err = Errno::from_raw_os_error(-err);
             return Err(err).context("Failed to configure net mode");
+        }
+    }
+
+    if let Ok(run_path) = env::var("XDG_RUNTIME_DIR") {
+        let pulse_path = Path::new(&run_path).join("pulse/native");
+        if pulse_path.exists() {
+            let pulse_path = CString::new(
+                pulse_path
+                    .to_str()
+                    .expect("pulse_path should not contain invalid UTF-8"),
+            )
+            .context("Failed to process `pulse/native` path as it contains NUL character")?;
+            // SAFETY: `pulse_path` is a pointer to a `CString` with long enough lifetime.
+            let err = unsafe { krun_add_vsock_port(ctx_id, 3333, pulse_path.as_ptr()) };
+            if err < 0 {
+                let err = Errno::from_raw_os_error(-err);
+                return Err(err).context("Failed to configure vsock for pulse socket");
+            }
         }
     }
 


### PR DESCRIPTION
    If $XDG_RUNTIME_DIR/pulse/native and /usr/bin/socat exist in the system,
    configure a vsock device pointing to the former and use the latter to
    act as a unix-socket to vsock proxy.

    This enables applications in the guest to access the pulseaudio socket
    in the host.