### PR TITLE
Raise RLIMIT_NOFILE in krun-guest

### DIFF
--- a/crates/krun-guest/Cargo.toml
+++ b/crates/krun-guest/Cargo.toml
@@ -14,7 +14,7 @@ bpaf = { workspace = true, features = [] }
 env_logger = { workspace = true, features = ["auto-color", "humantime", "unstable-kv"] }
 log = { workspace = true, features = ["kv"] }
 nix = { workspace = true, features = ["user"] }
-rustix = { workspace = true, features = ["fs", "mount", "std", "system", "use-libc-auxv"] }
+rustix = { workspace = true, features = ["fs", "mount", "process", "std", "system", "use-libc-auxv"] }
 tempfile = { workspace = true, features = [] }
 utils = { workspace = true, features = [] }
 


### PR DESCRIPTION
This is required for wine's esync to work.