### PR TITLE
Drop support for TSI networking

### DIFF
--- a/crates/krun/src/bin/krun.rs
+++ b/crates/krun/src/bin/krun.rs
@@ -14,7 +14,7 @@ use krun::{
     cpu::{get_fallback_cores, get_performance_cores},
     lock::{lock_or_connect, LockResult},
     net::{connect_to_passt, start_passt},
-    types::{MiB, NetMode},
+    types::MiB,
 };
 use krun_sys::{
     krun_add_vsock_port, krun_create_ctx, krun_set_exec, krun_set_gpu_options, krun_set_log_level,
@@ -140,7 +140,7 @@ fn main() -> Result<()> {
         }
     }
 
-    if options.net == NetMode::PASST {
+    {
         let passt_fd: OwnedFd = if let Some(passt_socket) = options.passt_socket {
             connect_to_passt(passt_socket)
                 .context("Failed to connect to `passt`")?

--- a/crates/krun/src/cli_options.rs
+++ b/crates/krun/src/cli_options.rs
@@ -3,14 +3,13 @@ use std::{ops::Range, path::PathBuf};
 use anyhow::{anyhow, Context};
 use bpaf::{any, construct, long, positional, OptionParser, Parser};
 
-use crate::types::{MiB, NetMode};
+use crate::types::MiB;
 
 #[derive(Clone, Debug)]
 pub struct Options {
     pub cpu_list: Vec<Range<u16>>,
     pub env: Vec<(String, Option<String>)>,
     pub mem: Option<MiB>,
-    pub net: NetMode,
     pub passt_socket: Option<PathBuf>,
     pub server_port: u32,
     pub command: String,
@@ -70,19 +69,6 @@ pub fn options() -> OptionParser<Options> {
             "the maximum amount of RAM supported is 16384 MiB",
         )
         .optional();
-    let net = long("net")
-        .help(
-            "Set network mode
-            NET_MODE can be either PASST (default) or TSI",
-        )
-        .argument::<String>("NET_MODE")
-        .fallback("PASST".to_owned())
-        .display_fallback()
-        .parse(|s| match &*s.to_ascii_uppercase() {
-            "PASST" => Ok(NetMode::PASST),
-            "TSI" => Ok(NetMode::TSI),
-            _ => Err(anyhow!("invalid NET_MODE value")),
-        });
     let passt_socket = long("passt-socket")
         .help("Instead of starting passt, connect to passt socket at PATH")
         .argument("PATH")
@@ -104,7 +90,6 @@ pub fn options() -> OptionParser<Options> {
         cpu_list,
         env,
         mem,
-        net,
         passt_socket,
         server_port,
         // positionals

--- a/crates/krun/src/types.rs
+++ b/crates/krun/src/types.rs
@@ -3,12 +3,6 @@ use std::{num::ParseIntError, str::FromStr};
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct MiB(u32);
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-pub enum NetMode {
-    PASST = 0,
-    TSI,
-}
-
 impl From<u32> for MiB {
     fn from(value: u32) -> Self {
         Self(value)


### PR DESCRIPTION
The use case targeted by krun is not compatible with TSI networking, so  drop it as an option to avoid unnecessary confusion.
    
