### PR TITLE
server: listen on any interface

### DIFF
--- a/crates/krun-server/src/bin/krun-server.rs
+++ b/crates/krun-server/src/bin/krun-server.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
 
     let options = options().run();
 
-    let listener = TcpListener::bind(format!("127.0.0.1:{}", &options.server_port))?;
+    let listener = TcpListener::bind(format!("0.0.0.0:{}", &options.server_port))?;
     let listener_fd = listener.as_raw_fd();
 
     let server_thread = start_server(listener);


### PR DESCRIPTION
Listening on 127.0.0.1 doesn't allow passt to forward incoming connections.

Fixes #29 