### PR TITLE
Support native X11 forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3280efcf6d66bc77c2cf9b67dc8acee47a217d9be67dd590b3230dffe663724d"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +307,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bpaf",
+ "byteorder",
  "env_logger",
  "log",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ license = "MIT"
 anyhow = { version = "1.0.82", default-features = false }
 bindgen = { version = "0.69.4", default-features = false }
 bpaf = { version = "0.9.11", default-features = false }
+byteorder = { version = "1.5.0", default-features = false }
 env_logger = { version = "0.11.3", default-features = false }
 krun-sys = { path = "crates/krun-sys", default-features = false }
 log = { version = "0.4.21", default-features = false }

--- a/crates/krun-guest/Cargo.toml
+++ b/crates/krun-guest/Cargo.toml
@@ -11,6 +11,7 @@ license = { workspace = true }
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 bpaf = { workspace = true, features = [] }
+byteorder = { workspace = true, features = ["std"] }
 env_logger = { workspace = true, features = ["auto-color", "humantime", "unstable-kv"] }
 log = { workspace = true, features = ["kv"] }
 nix = { workspace = true, features = ["user"] }

--- a/crates/krun-guest/src/bin/krun-guest.rs
+++ b/crates/krun-guest/src/bin/krun-guest.rs
@@ -7,7 +7,7 @@ use krun_guest::cli_options::options;
 use krun_guest::fex::setup_fex;
 use krun_guest::mount::mount_filesystems;
 use krun_guest::net::configure_network;
-use krun_guest::pulse::setup_pulse_proxy;
+use krun_guest::socket::setup_socket_proxy;
 use krun_guest::sommelier::exec_sommelier;
 use krun_guest::user::setup_user;
 use log::debug;
@@ -46,7 +46,11 @@ fn main() -> Result<()> {
         Err(err) => return Err(err).context("Failed to set up user, bailing out"),
     };
 
-    setup_pulse_proxy(run_path)?;
+    let pulse_path = run_path.join("pulse");
+    std::fs::create_dir(&pulse_path)
+        .context("Failed to create `pulse` directory in `XDG_RUNTIME_DIR`")?;
+    let pulse_path = pulse_path.join("native");
+    setup_socket_proxy(pulse_path, 3333)?;
 
     // Will not return if successful.
     exec_sommelier(&options.command, &options.command_args)

--- a/crates/krun-guest/src/bin/krun-guest.rs
+++ b/crates/krun-guest/src/bin/krun-guest.rs
@@ -10,6 +10,7 @@ use krun_guest::net::configure_network;
 use krun_guest::socket::setup_socket_proxy;
 use krun_guest::sommelier::exec_sommelier;
 use krun_guest::user::setup_user;
+use krun_guest::x11::setup_x11_forwarding;
 use log::debug;
 use rustix::process::{getrlimit, setrlimit, Resource};
 
@@ -51,6 +52,8 @@ fn main() -> Result<()> {
         .context("Failed to create `pulse` directory in `XDG_RUNTIME_DIR`")?;
     let pulse_path = pulse_path.join("native");
     setup_socket_proxy(pulse_path, 3333)?;
+
+    setup_x11_forwarding(run_path)?;
 
     // Will not return if successful.
     exec_sommelier(&options.command, &options.command_args)

--- a/crates/krun-guest/src/lib.rs
+++ b/crates/krun-guest/src/lib.rs
@@ -5,3 +5,4 @@ pub mod net;
 pub mod socket;
 pub mod sommelier;
 pub mod user;
+pub mod x11;

--- a/crates/krun-guest/src/lib.rs
+++ b/crates/krun-guest/src/lib.rs
@@ -2,6 +2,6 @@ pub mod cli_options;
 pub mod fex;
 pub mod mount;
 pub mod net;
-pub mod pulse;
+pub mod socket;
 pub mod sommelier;
 pub mod user;

--- a/crates/krun-guest/src/x11.rs
+++ b/crates/krun-guest/src/x11.rs
@@ -1,0 +1,90 @@
+use crate::socket::setup_socket_proxy;
+
+use anyhow::{anyhow, Context, Result};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::env;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+
+pub fn setup_x11_forwarding<P>(run_path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    // Set by krun if DISPLAY was provided from the host.
+    let host_display = match env::var("HOST_DISPLAY") {
+        Ok(d) => d,
+        Err(_) => return Ok(()),
+    };
+
+    if !host_display.starts_with(":") {
+        return Err(anyhow!("Invalid host DISPLAY"));
+    }
+    let host_display = &host_display[1..];
+
+    setup_socket_proxy(Path::new("/tmp/.X11-unix/X1"), 6000)?;
+
+    // Set HOST_DISPLAY to :1, which is the display number within the guest
+    // at which the actual host display is accessible.
+    // SAFETY: Safe if and only if `krun-guest` program is not multithreaded.
+    // See https://doc.rust-lang.org/std/env/fn.set_var.html#safety
+    env::set_var("HOST_DISPLAY", ":1");
+
+    if let Ok(xauthority) = std::env::var("XAUTHORITY") {
+        let src_path = format!("/run/krun-host/{}", xauthority);
+        let mut rdr = File::open(src_path)?;
+
+        let dst_path = run_path.as_ref().join("xauth");
+        let mut wtr = File::options()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&dst_path)
+            .context("Failed to create `xauth`")?;
+
+        while let Ok(family) = rdr.read_u16::<BigEndian>() {
+            let mut addr = vec![0u8; rdr.read_u16::<BigEndian>()? as usize];
+            rdr.read_exact(&mut addr)?;
+
+            let mut display = vec![0u8; rdr.read_u16::<BigEndian>()? as usize];
+            rdr.read_exact(&mut display)?;
+
+            let mut name = vec![0u8; rdr.read_u16::<BigEndian>()? as usize];
+            rdr.read_exact(&mut name)?;
+
+            let mut data = vec![0u8; rdr.read_u16::<BigEndian>()? as usize];
+            rdr.read_exact(&mut data)?;
+
+            // Only copy the wildcard entry
+            if family != 0xffff {
+                continue;
+            }
+
+            // Check for the correct host display
+            if display != host_display.as_bytes() {
+                continue;
+            }
+
+            // Always use display number 1
+            let display = b"1";
+
+            wtr.write_u16::<BigEndian>(family)?;
+            wtr.write_u16::<BigEndian>(addr.len().try_into()?)?;
+            wtr.write(&addr)?;
+            wtr.write_u16::<BigEndian>(display.len().try_into()?)?;
+            wtr.write(display)?;
+            wtr.write_u16::<BigEndian>(name.len().try_into()?)?;
+            wtr.write(&name)?;
+            wtr.write_u16::<BigEndian>(data.len().try_into()?)?;
+            wtr.write(&data)?;
+
+            break;
+        }
+
+        // SAFETY: Safe if and only if `krun-guest` program is not multithreaded.
+        // See https://doc.rust-lang.org/std/env/fn.set_var.html#safety
+        env::set_var("XAUTHORITY", dst_path);
+    }
+
+    Ok(())
+}

--- a/crates/krun/src/bin/krun.rs
+++ b/crates/krun/src/bin/krun.rs
@@ -181,6 +181,27 @@ fn main() -> Result<()> {
         }
     }
 
+    // Forward the native X11 display into the guest as a socket
+    if let Ok(x11_display) = env::var("DISPLAY") {
+        if x11_display.starts_with(":") {
+            let socket_path = Path::new("/tmp/.X11-unix/").join(format!("X{}", &x11_display[1..]));
+            if socket_path.exists() {
+                let socket_path = CString::new(
+                    socket_path
+                        .to_str()
+                        .expect("socket_path should not contain invalid UTF-8"),
+                )
+                .context("Failed to process dynamic socket path as it contains NUL character")?;
+                // SAFETY: `socket_path` is a pointer to a `CString` with long enough lifetime.
+                let err = unsafe { krun_add_vsock_port(ctx_id, 6000, socket_path.as_ptr()) };
+                if err < 0 {
+                    let err = Errno::from_raw_os_error(-err);
+                    return Err(err).context("Failed to configure vsock for host X11 socket");
+                }
+            }
+        }
+    }
+
     let username = env::var("USER").context("Failed to get username from environment")?;
     let user = User::from_name(&username)
         .map_err(Into::into)

--- a/crates/krun/src/env.rs
+++ b/crates/krun/src/env.rs
@@ -78,6 +78,19 @@ pub fn prepare_env_vars(env: Vec<(String, Option<String>)>) -> Result<HashMap<St
         env_map.insert(key, value);
     }
 
+    // If we have an X11 display in the host, set HOST_DISPLAY in the guest.
+    // krun-guest will then use this to set up xauth and replace it with :1
+    // (which is forwarded to the host display).
+    if let Ok(display) = env::var("DISPLAY") {
+        env_map.insert("HOST_DISPLAY".to_string(), display);
+
+        // And forward XAUTHORITY. This will be modified to fix the
+        // display name in krun-guest.
+        if let Ok(xauthority) = env::var("XAUTHORITY") {
+            env_map.insert("XAUTHORITY".to_string(), xauthority);
+        }
+    }
+
     debug!(env:? = env_map; "env vars");
 
     Ok(env_map)


### PR DESCRIPTION
If the host has DISPLAY set, parse it and forward that UNIX socket to the guest via vsock, then forward :1 on the guest to this vsock, and finally set HOST_DISPLAY=:1 on the guest.
    
Apps that want to directly talk to X11 on the host (instead of going through sommelier) should set DISPLAY=$HOST_DISPLAY and LIBGL_ALWAYS_SOFTWARE=true. This setup allows X11 apps in the host and the guest to cooperate (e.g. XEmbed) but requires software rendering inside the guest.
    
TODO: Figure out why things hang without LIGL_ALWAYS_SOFTWARE=true. Ideally DRI3 should fail and fall back to software automatically.
