### PR TITLE
Use uuidv7 for stdout / stderr files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +687,16 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "serde",
+ "uuid",
+]
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ tempfile = { version = "3.10.1", default-features = false }
 tokio = { version = "1.38.0", default-features = false }
 tokio-stream = { version = "0.1.15", default-features = false }
 utils = { path = "crates/utils", default-features = false }
+uuid = { version = "1.10.0", default-features = false }

--- a/crates/krun-guest/src/mount.rs
+++ b/crates/krun-guest/src/mount.rs
@@ -54,11 +54,12 @@ pub fn mount_filesystems() -> Result<()> {
 
     // Expose the host filesystem (without any overlaid mounts) as /run/krun-host
     let host_path = Path::new("/run/krun-host");
-    std::fs::create_dir_all(&host_path)?;
+    std::fs::create_dir_all(host_path)?;
     mount_bind("/", host_path).context("Failed to bind-mount / on /run/krun-host")?;
 
     if Path::new("/tmp/.X11-unix").exists() {
-        // Mount a tmpfs for X11 sockets, so the guest doesn't clobber host X server sockets
+        // Mount a tmpfs for X11 sockets, so the guest doesn't clobber host X server
+        // sockets
         mount2(
             Some("tmpfs"),
             "/tmp/.X11-unix",

--- a/crates/krun-guest/src/socket.rs
+++ b/crates/krun-guest/src/socket.rs
@@ -25,7 +25,7 @@ where
             socket_path
                 .as_ref()
                 .to_str()
-                .expect("pulse_path should not contain invalid UTF-8")
+                .expect("socket_path should not contain invalid UTF-8")
         ))
         .arg(format!("VSOCK-CONNECT:2:{}", port))
         .stdin(Stdio::null())

--- a/crates/krun-guest/src/x11.rs
+++ b/crates/krun-guest/src/x11.rs
@@ -1,11 +1,12 @@
-use crate::socket::setup_socket_proxy;
-
-use anyhow::{anyhow, Context, Result};
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::env;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+
+use crate::socket::setup_socket_proxy;
 
 pub fn setup_x11_forwarding<P>(run_path: P) -> Result<()>
 where
@@ -70,13 +71,13 @@ where
 
             wtr.write_u16::<BigEndian>(family)?;
             wtr.write_u16::<BigEndian>(addr.len().try_into()?)?;
-            wtr.write(&addr)?;
+            wtr.write_all(&addr)?;
             wtr.write_u16::<BigEndian>(display.len().try_into()?)?;
-            wtr.write(display)?;
+            wtr.write_all(display)?;
             wtr.write_u16::<BigEndian>(name.len().try_into()?)?;
-            wtr.write(&name)?;
+            wtr.write_all(&name)?;
             wtr.write_u16::<BigEndian>(data.len().try_into()?)?;
-            wtr.write(&data)?;
+            wtr.write_all(&data)?;
 
             break;
         }

--- a/crates/krun/src/bin/krun.rs
+++ b/crates/krun/src/bin/krun.rs
@@ -183,8 +183,8 @@ fn main() -> Result<()> {
 
     // Forward the native X11 display into the guest as a socket
     if let Ok(x11_display) = env::var("DISPLAY") {
-        if x11_display.starts_with(":") {
-            let socket_path = Path::new("/tmp/.X11-unix/").join(format!("X{}", &x11_display[1..]));
+        if let Some(x11_display) = x11_display.strip_prefix(":") {
+            let socket_path = Path::new("/tmp/.X11-unix/").join(format!("X{}", x11_display));
             if socket_path.exists() {
                 let socket_path = CString::new(
                     socket_path

--- a/crates/krun/src/net.rs
+++ b/crates/krun/src/net.rs
@@ -25,7 +25,8 @@ pub fn start_passt(server_port: u32) -> Result<UnixStream> {
 
     // SAFETY: The parent process should not keep the file descriptor of
     // `child_socket` open. It is a `UnixStream` so the file descriptor will be
-    // closed on drop. See https://doc.rust-lang.org/std/io/index.html#io-safety
+    // closed on drop.
+    // See https://doc.rust-lang.org/std/io/index.html#io-safety
     //
     // The `dup` call clears the `FD_CLOEXEC` flag on the new `child_fd`, which
     // should be inherited by the child process.

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive"] }
+uuid = { workspace = true, features = ["std", "v7"] }
 
 [features]
 default = []

--- a/crates/utils/src/stdio.rs
+++ b/crates/utils/src/stdio.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 use std::process::Stdio;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
+use uuid::Uuid;
 
 pub fn make_stdout_stderr<P>(command: P, envs: &HashMap<String, String>) -> Result<(Stdio, Stdio)>
 where
@@ -22,9 +22,9 @@ where
     } else {
         Path::new("/tmp")
     };
-    let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
-    let path_stdout = base.join(format!("krun-{filename}-{ts}.stdout"));
-    let path_stderr = base.join(format!("krun-{filename}-{ts}.stderr"));
+    let uuid = Uuid::now_v7();
+    let path_stdout = base.join(format!("krun-{filename}-{uuid}.stdout"));
+    let path_stderr = base.join(format!("krun-{filename}-{uuid}.stderr"));
     Ok((
         File::create_new(path_stdout)?.into(),
         File::create_new(path_stderr)?.into(),


### PR DESCRIPTION
It's too easy to hit the same millisecond...

Example of error message:

```
Error: File exists (os error 17)
```