### PR TITLE
WIP: Automatically manage FEX rootfs

### DIFF
--- a/crates/krun-guest/src/bin/krun-guest.rs
+++ b/crates/krun-guest/src/bin/krun-guest.rs
@@ -45,7 +45,9 @@ fn main() -> Result<()> {
     configure_network()?;
 
     if let Some(hidpipe_client_path) = find_in_path("hidpipe-client")? {
-        Command::new(hidpipe_client_path).arg(format!("{}", options.uid)).spawn()?;
+        Command::new(hidpipe_client_path)
+            .arg(format!("{}", options.uid))
+            .spawn()?;
     }
 
     let run_path = match setup_user(options.username, options.uid, options.gid) {

--- a/crates/krun-guest/src/mount.rs
+++ b/crates/krun-guest/src/mount.rs
@@ -1,12 +1,48 @@
+use std::ffi::CString;
 use std::fs::File;
 use std::os::fd::AsFd;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use rustix::fs::CWD;
+use rustix::fs::{mkdir, Mode, CWD};
 use rustix::mount::{
     mount2, mount_bind, move_mount, open_tree, MountFlags, MoveMountFlags, OpenTreeFlags,
 };
+
+fn mount_fex_rootfs() -> Result<()> {
+    let dir = "/run/fex-emu/";
+    let dir_base = dir.to_string() + "base";
+    let dir_mesa = dir.to_string() + "mesa";
+    let dir_rootfs = dir.to_string() + "rootfs";
+
+    // Create the directories for our mountpoints.
+    // This must succeed since /run/ was just mounted and is now an empty tmpfs.
+    for dir in [dir, &dir_base, &dir_mesa, &dir_rootfs] {
+        mkdir(
+            dir,
+            Mode::RUSR | Mode::XUSR | Mode::RGRP | Mode::XGRP | Mode::ROTH | Mode::XOTH,
+        )
+        .context("Failed to create FEX rootfs directory")?;
+    }
+
+    // Mount the squashfs images.
+    let fex_map = [(&dir_base, "/dev/vda"), (&dir_mesa, "/dev/vdb")];
+    let flags = MountFlags::RDONLY;
+
+    for (dir, disk) in fex_map {
+        mount2(Some(disk), dir, Some("squashfs"), flags, None)
+            .context("Failed to mount squashfs")?;
+    }
+
+    // Overlay the mounts together.
+    let opts = format!("lowerdir={}:{}", dir_mesa, dir_base);
+    let opts = CString::new(opts).unwrap();
+    let overlay = "overlay".to_string();
+    let overlay_ = Some(&overlay);
+    mount2(overlay_, &dir_rootfs, overlay_, flags, Some(&opts)).context("Failed to overlay")?;
+
+    Ok(())
+}
 
 pub fn mount_filesystems() -> Result<()> {
     mount2(
@@ -17,6 +53,10 @@ pub fn mount_filesystems() -> Result<()> {
         None,
     )
     .context("Failed to mount `/var/run`")?;
+
+    if let Err(_) = mount_fex_rootfs() {
+        println!("Failed to mount FEX rootfs, carrying on without.")
+    }
 
     let _ = File::options()
         .write(true)

--- a/crates/krun/src/cli_options.rs
+++ b/crates/krun/src/cli_options.rs
@@ -13,6 +13,8 @@ pub struct Options {
     pub mem: Option<MiB>,
     pub passt_socket: Option<PathBuf>,
     pub server_port: u32,
+    pub fex_rootfs: Option<String>,
+    pub fex_overlay: Option<String>,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -70,6 +72,16 @@ pub fn options() -> OptionParser<Options> {
             "the maximum amount of RAM supported is 16384 MiB",
         )
         .optional();
+    let fex_rootfs = long("fex-rootfs")
+        .short('r')
+        .help("Set squashfs file to be mounted as a FEX rootfs")
+        .argument::<String>("FEX_ROOTFS")
+        .optional();
+    let fex_overlay = long("fex-overlay")
+        .short('l')
+        .help("Set squashfs file to be overlaid over the FEX rootfs")
+        .argument::<String>("FEX_OVERLAY")
+        .optional();
     let passt_socket = long("passt-socket")
         .help("Instead of starting passt, connect to passt socket at PATH")
         .argument("PATH")
@@ -93,6 +105,8 @@ pub fn options() -> OptionParser<Options> {
         mem,
         passt_socket,
         server_port,
+        fex_rootfs,
+        fex_overlay,
         // positionals
         command,
         command_args,


### PR DESCRIPTION
This adds a mechanism for automatically managing the FEX rootfs, mounting and overlayfs'ing the relevant squashfs files from the host.

Depends on:

* libkrun https://github.com/containers/libkrun/pull/217
* libkrunfw https://github.com/containers/libkrunfw/pull/65